### PR TITLE
feat(ZNTA-2270): custom context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ node {
   mainScmGit = new ScmGit(env, steps, PROJ_URL)
   mainScmGit.init(env.BRANCH_NAME)
   notify = new Notifier(env, steps, currentBuild,
-    pipelineLibraryScmGit, mainScmGit, 'Jenkinsfile',
+    pipelineLibraryScmGit, mainScmGit, (env.GITHUB_COMMIT_CONTEXT) ?: 'Jenkinsfile',
   )
   defaultNodeLabel = env.DEFAULT_NODE ?: 'master || !master'
   // eg github-zanata-org/zanata-platform/update-Jenkinsfile


### PR DESCRIPTION
Different Jenkins  context can be specified as  GITHUB_COMMIT_CONTEXT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-jenkins-plugin/2)
<!-- Reviewable:end -->
